### PR TITLE
New Feature: callback on close

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ Using the plugin:
     ``$('#foo').prepend('Print this page');
     $('a.print-preview').printPreview();``
 
+Properties:
+
+    close_cb - Add a function callback that is called when the preview is closed.
+
+    Example:
+      $('a.preview').bind('click', function(e) {
+          e.preventDefault();
+          var pp = jQuery.printPreview;
+          pp.close_cb = function(){ alert('all done') };
+          pp.loadPrintPreview();
+      });
+
 ## Supported Browsers
 - Internet Explorer 6, 7, 8 and 9
 - Safari

--- a/src/jquery.print-preview.js
+++ b/src/jquery.print-preview.js
@@ -26,6 +26,7 @@
     // Private functions
     var mask, size, print_modal, print_controls;
     $.printPreview = {
+        close_cb: function(){},
         loadPrintPreview: function() {
             // Declare DOM objects
             print_modal = $('<div id="print-modal"></div>');
@@ -126,6 +127,7 @@
     	},
     	
     	distroyPrintPreview: function() {
+    	    var self = this;
     	    print_controls.fadeOut(100);
     	    print_modal.animate({ top: $(window).scrollTop() - $(window).height(), opacity: 1}, 400, 'linear', function(){
     	        print_modal.remove();
@@ -133,6 +135,7 @@
     	    });
     	    mask.fadeOut('slow', function()  {
     			mask.remove();
+    			self.close_cb.call(self);
     		});				
 
     		$(document).unbind("keydown.printPreview.mask");


### PR DESCRIPTION
I have added a new feature (and documentation) that allows a user to add a callback function that gets called when the print preview window is closed.  There might be a better way to set the property in the Initialization code but I wanted to keep the diff simple.
