### PR TITLE
Update to jQuery 1.10.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # jQuery Print Preview plugin
+## 9-18-13 Updates
+- Updated correct for $.browser being deprecated in jQuery 1.9 (side-effect: removed support for IE 7 & below)
+- Updated demo file to use jQuery 1.10.2 & removed carousel which was dependent on the jquerytools library that was previously being used. 
+
 The jQuery Print Preview plugin is designed to provide visitors with a preview of the print version of a web site.
 Unlike traditional print previews this plugin brings in all content and print styles within a modal window.
 
-[Check out the demo](http://etimbo.github.com/jquery-print-preview-plugin/example/index.html)
+[Check out the demo](http://briceshatzer.github.com/jquery-print-preview-plugin/example/index.html)
 
 ## Usage
 Prerequisites:
@@ -19,7 +23,7 @@ Using the plugin:
     $('a.print-preview').printPreview();``
 
 ## Supported Browsers
-- Internet Explorer 6, 7, 8 and 9
+- Internet Explorer 8, 9, and 10
 - Safari
 - Google Chrome
 - Firefox

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jQuery Print Preview plugin
 ## 9-18-13 Updates
-- Updated correct for $.browser being deprecated in jQuery 1.9 (side-effect: removed support for IE 7 & below)
+- Updated for $.browser being deprecated in jQuery 1.9 (side-effect: removed support for IE 7 & below)
 - Updated demo file to use jQuery 1.10.2 & removed carousel which was dependent on the jquerytools library that was previously being used. 
 
 The jQuery Print Preview plugin is designed to provide visitors with a preview of the print version of a web site.

--- a/example/index.html
+++ b/example/index.html
@@ -6,15 +6,10 @@
     <link rel="stylesheet" href="css/screen.css" type="text/css" media="screen" />
     <link rel="stylesheet" href="css/print.css" type="text/css" media="print" />
     <link rel="stylesheet" href="../src/css/print-preview.css" type="text/css" media="screen">
-    <script src="http://cdn.jquerytools.org/1.2.5/full/jquery.tools.min.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
     <script src="../src/jquery.print-preview.js" type="text/javascript" charset="utf-8"></script>
     <script type="text/javascript">
         $(function() {
-            /*
-             * Initialise example carousel
-             */
-            $("#feature > div").scrollable({interval: 2000}).autoscroll();
-            
             /*
              * Initialise print preview plugin
              */
@@ -45,20 +40,11 @@
         <h1>Sed do eiusmod tempor</h1>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
         <div id="feature">
-            <a class="prev disabled">L</a>
             <div>
                 <div class="items">
-                    <!-- <div><img src="http://flickholdr.com/620/175/dark" alt="" /></div>
-                    <div><img src="http://flickholdr.com/620/175/black" alt="" /></div>
-                    <div><img src="http://flickholdr.com/620/175/doom" alt="" /></div>
-                    <div><img src="http://flickholdr.com/620/175/red" alt="" /></div> -->
                     <div><img src="images/feature-1.jpg" alt="" /></div>
-                    <div><img src="images/feature-2.jpg" alt="" /></div>
-                    <div><img src="images/feature-3.jpg" alt="" /></div>
-                    <div><img src="images/feature-4.jpg" alt="" /></div>
                 </div>
             </div>
-            <a class="next">R</a>
         </div>
         <h2>Labore et dolore magna</h2>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>

--- a/src/jquery.print-preview.js
+++ b/src/jquery.print-preview.js
@@ -9,6 +9,12 @@
  */
  
 (function($) { 
+//replaces $.browser functionality that was deprecated in jQuery 1.9
+jQuery.browser = {};
+jQuery.browser.mozilla = /mozilla/.test(navigator.userAgent.toLowerCase()) && !/webkit/.test(navigator.userAgent.toLowerCase());
+jQuery.browser.webkit = /webkit/.test(navigator.userAgent.toLowerCase());
+jQuery.browser.opera = /opera/.test(navigator.userAgent.toLowerCase());
+jQuery.browser.msie = /msie/.test(navigator.userAgent.toLowerCase());    
     
 	// Initialization
 	$.fn.printPreview = function() {
@@ -62,18 +68,8 @@
             $iframe_head.each(function() {
                 $(this).attr('media', 'all');
             });
-            if (!$.browser.msie && !($.browser.version < 7) ) {
                 $('head', print_frame_ref).append($iframe_head);
                 $('body', print_frame_ref).append($iframe_body);
-            }
-            else {
-                $('body > *:not(#print-modal):not(script)').clone().each(function() {
-                    $('body', print_frame_ref).append(this.outerHTML);
-                });
-                $('head link[media*=print], head link[media=all]').each(function() {
-                    $('head', print_frame_ref).append($(this).clone().attr('media', 'all')[0].outerHTML);
-                });
-            }
             
             // Disable all links
             $('a', print_frame_ref).bind('click.printPreview', function(e) {


### PR DESCRIPTION
Fixes issue #20 & #21 
- Updated correct for $.browser being deprecated in jQuery 1.9
  (side-effect: removed support for IE 7 & below)
- Updated demo file to use jQuery 1.10.2 & removed carousel which was
  dependent on the jquerytools library that was previously being used.
